### PR TITLE
test: remove migration initializer from the NewMySQLContainer function

### DIFF
--- a/database/gorm/gorm_test.go
+++ b/database/gorm/gorm_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Test GORM", func() {
 })
 
 var _ = BeforeSuite(func() {
-	mySQLContainer, _ = test.NewMySQLContainer("")
+	mySQLContainer, _ = test.NewMySQLContainer(mysql.DefaultMySQLOptions)
 	mySQLContainer.Start()
 })
 

--- a/database/gorm/gorm_test.go
+++ b/database/gorm/gorm_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Test GORM", func() {
 })
 
 var _ = BeforeSuite(func() {
-	mySQLContainer, _ = test.NewMySQLContainer(mysql.DefaultMySQLOptions)
+	mySQLContainer, _ = test.NewMySQLContainer(test.DefaultMySQLOptions)
 	mySQLContainer.Start()
 })
 

--- a/test/docker.go
+++ b/test/docker.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	docker "github.com/fsouza/go-dockerclient"
@@ -80,8 +81,7 @@ func NewDockerContainer(opts ...Option) *Container {
 		Context: context.TODO(),
 	})
 	if err != nil {
-		log.Error("Failed to create a container", "repository", c.imageRespository, "tag", c.imageTag, "err", err)
-		return nil
+		panic(fmt.Errorf("Failed to create a container %s:%s error:%s", c.imageRespository, c.imageTag, err))
 	}
 
 	return c

--- a/test/docker.go
+++ b/test/docker.go
@@ -21,7 +21,6 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/getamis/sirius/crypto/rand"
-	"github.com/getamis/sirius/log"
 )
 
 type Container struct {

--- a/test/mysql.go
+++ b/test/mysql.go
@@ -17,6 +17,7 @@ package test
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/getamis/sirius/database/mysql"
@@ -108,10 +109,28 @@ type MySQLOptions struct {
 var DefaultMySQLOptions = MySQLOptions{
 	Username: "root",
 	Password: "my-secret-pw",
-	Port:     3306,
+
+	// Currently the port will be published to the host.
+	Port: 3306,
+
+	// The db we want to run the test
 	Database: "db0",
 
+	// the mysql host to be connected from the client
+	// if we're running test on the host, we might need to connect to the mysql
+	// server via 127.0.0.1:3306. however if we want to run the test inside the container,
+	// we need to inspect the IP of the container
 	Host: "127.0.0.1",
+}
+
+func IsInsideContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/bin/running-in-container"); err == nil {
+		return true
+	}
+	return false
 }
 
 func NewMySQLContainer(options MySQLOptions, containerOptions ...Option) (*MySQLContainer, error) {

--- a/test/mysql.go
+++ b/test/mysql.go
@@ -144,7 +144,7 @@ func NewMySQLContainer(options MySQLOptions, containerOptions ...Option) (*MySQL
 
 	// Once the mysql container is ready, we will create the database if it does not exist.
 	checker := func(c *Container) error {
-		return retry(10, 5*time.Second, func() error {
+		return retry(10, 10*time.Second, func() error {
 			db, err := sql.Open("mysql", connectionString)
 			if err != nil {
 				return err

--- a/test/mysql.go
+++ b/test/mysql.go
@@ -114,7 +114,7 @@ var DefaultMySQLOptions = MySQLOptions{
 	Host: "127.0.0.1",
 }
 
-func NewMySQLContainer(options MySQLOptions) (*MySQLContainer, error) {
+func NewMySQLContainer(options MySQLOptions, containerOptions ...Option) (*MySQLContainer, error) {
 
 	// We use this connection string to verify the mysql container is ready.
 	connectionString, _ := mysql.ToConnectionString(
@@ -139,16 +139,21 @@ func NewMySQLContainer(options MySQLOptions) (*MySQLContainer, error) {
 	// Create the container, please note that the container is not started yet.
 	container := &MySQLContainer{
 		dockerContainer: NewDockerContainer(
-			ImageRepository("mysql"),
-			ImageTag("5.7"),
-			Ports(options.Port),
-			DockerEnv(
-				[]string{
-					fmt.Sprintf("MYSQL_ROOT_PASSWORD=%s", options.Password),
-					fmt.Sprintf("MYSQL_DATABASE=%s", options.Database),
-				},
-			),
-			HealthChecker(checker),
+			// this is to keep some flexibility for passing extra container options..
+			// however if we literally use "..." in the method call, an error
+			// "too many arguments" will raise.
+			append([]Option{
+				ImageRepository("mysql"),
+				ImageTag("5.7"),
+				Ports(options.Port),
+				DockerEnv(
+					[]string{
+						fmt.Sprintf("MYSQL_ROOT_PASSWORD=%s", options.Password),
+						fmt.Sprintf("MYSQL_DATABASE=%s", options.Database),
+					},
+				),
+				HealthChecker(checker),
+			}, containerOptions...)...,
 		),
 	}
 

--- a/test/mysql_test.go
+++ b/test/mysql_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMySQLContainer(t *testing.T) {
-	container, _ := NewMySQLContainer("")
+	container, _ := NewMySQLContainer(DefaultMySQLOptions)
 	assert.NotNil(t, container)
 	assert.NoError(t, container.Start())
 


### PR DESCRIPTION
## Purpose

This is to make the NewMySQLContainer function simpler, so that we can connect the mysql container and the migration container to the bridge network later.

Please notice this PR does remove the migration initializer, so that packages using NewMySQLContainer should setup their initializer. 

