### PR TITLE
test: provide mysql setup/teardown functions for running tests against the host mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - "1.10"
 
 services:
-  - docker
+- docker
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ branches:
 jobs:
   include:
     - stage: Host MySQL Test
+      env:
+      - TEST_MYSQL_HOST=127.0.0.1
+      - TEST_MYSQL_PORT=3306
+      - TEST_MYSQL_PASSWORD=""
       script:
-      - TEST_MYSQL_HOST=127.0.0.1 TEST_MYSQL_PORT=3306 TEST_MYSQL_PASSWORD="" go test ./test
+      - go test ./test
     - stage: Unit Test
       script:
       - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
       - docker-ce
 
 before_script:
-  - sudo service mysql stop
   - make deps
 
 branches:
@@ -22,8 +21,12 @@ branches:
 
 jobs:
   include:
+    - stage: Host MySQL Test
+      script:
+      - TEST_MYSQL_HOST=127.0.0.1 TEST_MYSQL_PORT=3306 TEST_MYSQL_PASSWORD="" go test ./test
     - stage: Unit Test
-      script: make test
+      script:
+      - make test
     - stage: Release
       if: tag =~ ^v
       env: REV="$TRAVIS_TAG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 
 services:
 - docker
+- mysql
 
 addons:
   apt:

--- a/database/gorm/gorm_test.go
+++ b/database/gorm/gorm_test.go
@@ -59,8 +59,12 @@ var _ = Describe("Test GORM", func() {
 })
 
 var _ = BeforeSuite(func() {
-	mySQLContainer, _ = test.NewMySQLContainer(test.DefaultMySQLOptions)
-	mySQLContainer.Start()
+	var err error
+	options := test.LoadMySQLOptions()
+	mySQLContainer, err = test.NewMySQLContainer(options)
+	Expect(err).Should(BeNil(), "mysql container should be created")
+	err = mySQLContainer.Start()
+	Expect(err).Should(BeNil(), "mysql container should be started")
 })
 
 var _ = AfterSuite(func() {

--- a/test/docker.go
+++ b/test/docker.go
@@ -50,10 +50,11 @@ func NewDockerContainer(opts ...Option) *Container {
 		opt(c)
 	}
 
-	portBindings := make(map[docker.Port][]docker.PortBinding)
-	exposedPorts := make(map[docker.Port]struct{})
-
-	if len(c.ports) != 0 {
+	var portBindings map[docker.Port][]docker.PortBinding = nil
+	var exposedPorts map[docker.Port]struct{} = nil
+	if len(c.ports) > 0 {
+		exposedPorts = make(map[docker.Port]struct{})
+		portBindings = make(map[docker.Port][]docker.PortBinding)
 		for _, port := range c.ports {
 			portBindings[docker.Port(port)] = []docker.PortBinding{
 				{

--- a/test/docker.go
+++ b/test/docker.go
@@ -32,11 +32,11 @@ type Container struct {
 	runArgs          []string
 	envs             []string
 	container        *docker.Container
-	healthChecker    healthChecker
-	initializer      func(*Container) error
+	healthChecker    ContainerCallback
+	initializer      ContainerCallback
 }
 
-type healthChecker func(*Container) error
+type ContainerCallback func(*Container) error
 
 func NewDockerContainer(opts ...Option) *Container {
 	c := &Container{
@@ -94,6 +94,10 @@ func newDockerClient() *docker.Client {
 		client, _ = docker.NewClient("unix:///var/run/docker.sock")
 	}
 	return client
+}
+
+func (c *Container) OnReady(initializer ContainerCallback) {
+	c.initializer = initializer
 }
 
 func (c *Container) Start() error {

--- a/test/docker_options.go
+++ b/test/docker_options.go
@@ -58,7 +58,7 @@ func DockerEnv(env []string) Option {
 	}
 }
 
-func HealthChecker(checker healthChecker) Option {
+func HealthChecker(checker ContainerCallback) Option {
 	return func(c *Container) {
 		c.healthChecker = checker
 	}

--- a/test/docker_options.go
+++ b/test/docker_options.go
@@ -36,6 +36,29 @@ func ImageTag(tag string) Option {
 	}
 }
 
+type PortBinding struct {
+	ContainerPort string
+	HostPort      string
+}
+
+func HostPortBindings(bindings ...PortBinding) Option {
+	return func(c *Container) {
+		for _, binding := range bindings {
+			c.addHostPortBinding(binding.ContainerPort, binding.HostPort)
+		}
+	}
+}
+
+func ExposePorts(ports ...string) Option {
+	return func(c *Container) {
+		for _, port := range ports {
+			c.exposePort(port)
+		}
+	}
+}
+
+// Ports function automatically combines port bindings and exposes ports of the
+// container
 func Ports(ports ...int) Option {
 	return func(c *Container) {
 		var p []string

--- a/test/mysql.go
+++ b/test/mysql.go
@@ -247,6 +247,11 @@ func NewMySQLContainer(options MySQLOptions, containerOptions ...Option) (*MySQL
 	// Once the mysql container is ready, we will create the database if it does not exist.
 	checker := NewMySQLHealthChecker(options)
 
+	// we should publish the ports only when we're on the host
+	if !IsInsideContainer() {
+		containerOptions = append(containerOptions, Ports(options.Port))
+	}
+
 	// Create the container, please note that the container is not started yet.
 	container := &MySQLContainer{
 		dockerContainer: NewDockerContainer(
@@ -256,7 +261,6 @@ func NewMySQLContainer(options MySQLOptions, containerOptions ...Option) (*MySQL
 			append([]Option{
 				ImageRepository("mysql"),
 				ImageTag("5.7"),
-				Ports(options.Port),
 				DockerEnv(
 					[]string{
 						fmt.Sprintf("MYSQL_ROOT_PASSWORD=%s", options.Password),

--- a/test/mysql.go
+++ b/test/mysql.go
@@ -44,7 +44,12 @@ func (container *MySQLContainer) Suspend() error {
 }
 
 func (container *MySQLContainer) Stop() error {
-	if container.Started {
+	container.Started = false
+	return container.dockerContainer.Stop()
+}
+
+func (container *MySQLContainer) Teardown() error {
+	if container.dockerContainer != nil && container.Started {
 		container.Started = false
 		return container.dockerContainer.Stop()
 	}

--- a/test/mysql.go
+++ b/test/mysql.go
@@ -186,35 +186,39 @@ func ToMySQLConnectionString(c *Container, options MySQLOptions) (string, error)
 	)
 }
 
+func LoadMySQLOptions() MySQLOptions {
+	options := DefaultMySQLOptions
+	if host, ok := os.LookupEnv("TEST_MYSQL_HOST"); ok {
+		options.Host = host
+	}
+	if val, ok := os.LookupEnv("TEST_MYSQL_PORT"); ok {
+		options.Port = val
+	}
+
+	if val, ok := os.LookupEnv("TEST_MYSQL_DATABASE"); ok {
+		options.Database = val
+	}
+
+	if val, ok := os.LookupEnv("TEST_MYSQL_USERNAME"); ok {
+		options.Username = val
+	}
+
+	if val, ok := os.LookupEnv("TEST_MYSQL_PASSWORD"); ok {
+		options.Password = val
+	}
+	return options
+}
+
 // setup the mysql connection
 // if TEST_MYSQL_HOST is defined, then we will use the connection directly.
 // if not, a mysql container will be started
 func SetupMySQL() (*MySQLContainer, error) {
-	if host, ok := os.LookupEnv("TEST_MYSQL_HOST"); ok {
-		port := DefaultMySQLOptions.Port
-		if val, ok := os.LookupEnv("TEST_MYSQL_PORT"); ok {
-			port = val
-		}
-
-		database := DefaultMySQLOptions.Database
-		if val, ok := os.LookupEnv("TEST_MYSQL_DATABASE"); ok {
-			database = val
-		}
-
-		username := DefaultMySQLOptions.Username
-		if val, ok := os.LookupEnv("TEST_MYSQL_USERNAME"); ok {
-			username = val
-		}
-
-		password := DefaultMySQLOptions.Password
-		if val, ok := os.LookupEnv("TEST_MYSQL_PASSWORD"); ok {
-			password = val
-		}
-
+	if _, ok := os.LookupEnv("TEST_MYSQL_HOST"); ok {
+		options := LoadMySQLOptions()
 		connectionString, err := mysql.ToConnectionString(
-			mysql.Connector(mysql.DefaultProtocol, host, port),
-			mysql.Database(database),
-			mysql.UserInfo(username, password),
+			mysql.Connector(mysql.DefaultProtocol, options.Host, options.Port),
+			mysql.Database(options.Database),
+			mysql.UserInfo(options.Username, options.Password),
 		)
 		if err != nil {
 			return nil, err

--- a/test/mysql.go
+++ b/test/mysql.go
@@ -249,6 +249,8 @@ func NewMySQLContainer(options MySQLOptions, containerOptions ...Option) (*MySQL
 		// mysql container port always expose the server port on 3306
 		containerOptions = append(containerOptions, ExposePorts("3306"))
 		containerOptions = append(containerOptions, HostPortBindings(PortBinding{"3306/tcp", options.Port}))
+	} else {
+		containerOptions = append(containerOptions, ExposePorts("3306"))
 	}
 
 	// Create the container, please note that the container is not started yet.

--- a/test/mysql_test.go
+++ b/test/mysql_test.go
@@ -24,12 +24,13 @@ import (
 )
 
 func TestMySQLContainer(t *testing.T) {
-	container, _ := NewMySQLContainer(DefaultMySQLOptions)
+	container, err := NewMySQLContainer(DefaultMySQLOptions)
+	assert.NoError(t, err, "mysql container should be created.")
 	assert.NotNil(t, container)
-	assert.NoError(t, container.Start())
+	assert.NoError(t, container.Start(), "mysql container should be started")
 
 	db, err := gorm.Open("mysql", container.URL)
-	assert.NoError(t, err, "should be no error")
+	assert.NoError(t, err, "mysql connection should work")
 	db.Close()
 
 	// stop MySQL

--- a/test/mysql_test.go
+++ b/test/mysql_test.go
@@ -32,7 +32,9 @@ func TestMySQLSetupAndTeardown(t *testing.T) {
 }
 
 func TestMySQLContainer(t *testing.T) {
-	container, err := NewMySQLContainer(DefaultMySQLOptions)
+	options := LoadMySQLOptions()
+
+	container, err := NewMySQLContainer(options)
 	assert.NoError(t, err, "mysql container should be created.")
 	assert.NotNil(t, container)
 	assert.NoError(t, container.Start(), "mysql container should be started")

--- a/test/mysql_test.go
+++ b/test/mysql_test.go
@@ -47,6 +47,7 @@ func TestMySQLContainer(t *testing.T) {
 	// close MySQL
 	assert.NoError(t, container.Stop())
 	time.Sleep(100 * time.Millisecond)
+
 	_, err = gorm.Open("mysql", container.URL)
 	assert.Error(t, err, "should got error")
 }

--- a/test/mysql_test.go
+++ b/test/mysql_test.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -24,14 +25,23 @@ import (
 )
 
 func TestMySQLSetupAndTeardown(t *testing.T) {
-	mysql, err := SetupMySQL()
+	mysql, err := SetupMySQL(t)
 	assert.NoError(t, err, "mysql connection handle should be created.")
+	assert.NotNil(t, mysql, "the mysql container should be returned.")
+
+	db, err := gorm.Open("mysql", mysql.URL)
+	assert.NoError(t, err, "mysql connection should work")
+	db.Close()
 
 	err = mysql.Teardown()
 	assert.NoError(t, err, "mysql connection handle should be torn down.")
 }
 
 func TestMySQLContainer(t *testing.T) {
+	if _, ok := os.LookupEnv("TEST_MYSQL_HOST"); ok {
+		t.Skip("mysql container test is ignored when mysql host is enabled.")
+	}
+
 	options := LoadMySQLOptions()
 
 	container, err := NewMySQLContainer(options)

--- a/test/mysql_test.go
+++ b/test/mysql_test.go
@@ -23,6 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMySQLSetupAndTeardown(t *testing.T) {
+	mysql, err := SetupMySQL()
+	assert.NoError(t, err, "mysql connection handle should be created.")
+
+	err = mysql.Teardown()
+	assert.NoError(t, err, "mysql connection handle should be torn down.")
+}
+
 func TestMySQLContainer(t *testing.T) {
 	container, err := NewMySQLContainer(DefaultMySQLOptions)
 	assert.NoError(t, err, "mysql container should be created.")


### PR DESCRIPTION
## Purpose

Allow tests to connect to  the mysql on the host.

## Changes

### Add More Environment Variables

- `TEST_MYSQL_HOST` when this variable is set, the mysql container will not be started. the given host will be used for the tests.
- `TEST_MYSQL_PORT`
- `TEST_MYSQL_USERNAME`
- `TEST_MYSQL_PASSWORD`

### Add one test case to travis-ci

The following command will be executed to test the mysql host connection setup.

```
TEST_MYSQL_HOST=127.0.0.1 TEST_MYSQL_PORT=3306 TEST_MYSQL_PASSWORD="" go test ./test
```

### API Changes

#### `test.SetupMySQL`

`SetupMySQL` wraps the `NewMySQLContainer`.
It creates the mysql container when the `TEST_MYSQL_HOST` is not set.  the connection string will be generated when the `TEST_MYSQL_HOST` is defined. 

#### `MySQLContainer.Teardown`

The teardown method handles the container clean up.



